### PR TITLE
Qgis3 update : shp layer source

### DIFF
--- a/pstimeseries_plugin.py
+++ b/pstimeseries_plugin.py
@@ -114,7 +114,7 @@ class PSTimeSeries_Plugin:
 		x, y = [], []	# lists containg x,y values
 		infoFields = {}	# hold the index->name of the fields containing info to be displayed
 
-		ps_source = ps_layer.source()
+		ps_source = ps_layer.source().split('|')[0]
 		ps_fields = ps_layer.dataProvider().fields()
 
 		providerType = ps_layer.providerType()


### PR DESCRIPTION
In Qgis3 layer source is composed of two parts :
{The SHP file directory ending with .shp}|{The layer name in qgis}
We have to split it on this character '|' and use the first part which ends with .shp